### PR TITLE
Continuing PR#7

### DIFF
--- a/shorttext/classifiers/embed/nnlib/VarNNEmbedVecClassification.py
+++ b/shorttext/classifiers/embed/nnlib/VarNNEmbedVecClassification.py
@@ -106,12 +106,12 @@ class VarNNEmbeddedVecClassifier:
                 category_bucket = [0]*len(classlabels)
                 category_bucket[lblidx_dict[label]] = 1
                 indices.append(category_bucket)
-                if self.with_gensim == True:
+                if self.with_gensim:
                     phrases.append(shorttext)
                 else:
                     phrases.append(tokenize(shorttext))
 
-        if self.with_gensim == True:
+        if self.with_gensim:
             return classlabels, phrases, indices
 
         # store embedded vectors
@@ -272,7 +272,7 @@ class VarNNEmbeddedVecClassifier:
         if not self.trained:
             raise e.ModelNotTrainedException()
 
-        if self.with_gensim == True:
+        if self.with_gensim:
             # tokenize and pad input text
             matrix = self.process_text(shorttext)
         else:

--- a/shorttext/classifiers/embed/nnlib/VarNNEmbedVecClassification.py
+++ b/shorttext/classifiers/embed/nnlib/VarNNEmbedVecClassification.py
@@ -67,11 +67,11 @@ class VarNNEmbeddedVecClassifier:
     >>> classifier.score('artificial intelligence')
     {'mathematics': 0.57749695, 'physics': 0.33749574, 'theology': 0.085007325}
     """
-    def __init__(self, wvmodel, vecsize=300, maxlen=15, with_gensim=False):
+    def __init__(self, wvmodel, vecsize=100, maxlen=15, with_gensim=False):
         """ Initialize the classifier.
 
         :param wvmodel: Word2Vec model
-        :param vecsize: length of the embedded vectors in the model (Default: 300)
+        :param vecsize: length of the embedded vectors in the model (Default: 100)
         :param maxlen: maximum number of words in a sentence (Default: 15)
         :type wvmodel: gensim.models.keyedvectors.KeyedVectors
         :type vecsize: int

--- a/shorttext/classifiers/embed/nnlib/frameworks.py
+++ b/shorttext/classifiers/embed/nnlib/frameworks.py
@@ -128,6 +128,7 @@ def DoubleCNNWordEmbed(nb_labels,
     :param optimizer: optimizer for gradient descent. Options: sgd, rmsprop, adagrad, adadelta, adam, adamax, nadam. (Default: adam)
     :return: keras sequantial model for CNN/ConvNet for Word-Embeddings
     :type nb_labels: int
+    :type wvmodel: gensim.models.keyedvectors.KeyedVectors
     :type nb_filters_1: int
     :type nb_filters_2: int
     :type n_gram: int
@@ -234,6 +235,7 @@ def CLSTMWordEmbed(nb_labels,
     :param optimizer: optimizer for gradient descent. Options: sgd, rmsprop, adagrad, adadelta, adam, adamax, nadam. (Default: adam)
     :return: keras sequantial model for CNN/ConvNet for Word-Embeddings
     :type nb_labels: int
+    :type wvmodel: gensim.models.keyedvectors.KeyedVectors
     :type nb_filters: int
     :type n_gram: int
     :type maxlen: int

--- a/shorttext/classifiers/embed/nnlib/frameworks.py
+++ b/shorttext/classifiers/embed/nnlib/frameworks.py
@@ -14,7 +14,7 @@ def CNNWordEmbed(nb_labels,
                  nb_filters=1200,
                  n_gram=2,
                  maxlen=15,
-                 vecsize=300,
+                 vecsize=100,
                  cnn_dropout=0.0,
                  final_activation='softmax',
                  dense_wl2reg=0.0,
@@ -32,7 +32,7 @@ def CNNWordEmbed(nb_labels,
     :param nb_filters: number of filters (Default: 1200)
     :param n_gram: n-gram, or window size of CNN/ConvNet (Default: 2)
     :param maxlen: maximum number of words in a sentence (Default: 15)
-    :param vecsize: length of the embedded vectors in the model (Default: 300)
+    :param vecsize: length of the embedded vectors in the model (Default: 100)
     :param cnn_dropout: dropout rate for CNN/ConvNet (Default: 0.0)
     :param final_activation: activation function. Options: softplus, softsign, relu, tanh, sigmoid, hard_sigmoid, linear. (Default: 'softmax')
     :param dense_wl2reg: L2 regularization coefficient (Default: 0.0)
@@ -102,7 +102,7 @@ def DoubleCNNWordEmbed(nb_labels,
                        n_gram=2,
                        filter_length_2=10,
                        maxlen=15,
-                       vecsize=300,
+                       vecsize=100,
                        cnn_dropout_1=0.0,
                        cnn_dropout_2=0.0,
                        final_activation='softmax',
@@ -119,7 +119,7 @@ def DoubleCNNWordEmbed(nb_labels,
     :param n_gram: n-gram, or window size of first CNN/ConvNet (Default: 2)
     :param filter_length_2: window size for second CNN/ConvNet layer (Default: 10)
     :param maxlen: maximum number of words in a sentence (Default: 15)
-    :param vecsize: length of the embedded vectors in the model (Default: 300)
+    :param vecsize: length of the embedded vectors in the model (Default: 100)
     :param cnn_dropout_1: dropout rate for the first CNN/ConvNet layer (Default: 0.0)
     :param cnn_dropout_2: dropout rate for the second CNN/ConvNet layer (Default: 0.0)
     :param final_activation: activation function. Options: softplus, softsign, relu, tanh, sigmoid, hard_sigmoid, linear. (Default: 'softmax')
@@ -203,7 +203,7 @@ def CLSTMWordEmbed(nb_labels,
                    nb_filters=1200,
                    n_gram=2,
                    maxlen=15,
-                   vecsize=300,
+                   vecsize=100,
                    cnn_dropout=0.0,
                    nb_rnnoutdim=1200,
                    rnn_dropout=0.2,
@@ -224,7 +224,7 @@ def CLSTMWordEmbed(nb_labels,
     :param nb_filters: number of filters (Default: 1200)
     :param n_gram: n-gram, or window size of CNN/ConvNet (Default: 2)
     :param maxlen: maximum number of words in a sentence (Default: 15)
-    :param vecsize: length of the embedded vectors in the model (Default: 300)
+    :param vecsize: length of the embedded vectors in the model (Default: 100)
     :param cnn_dropout: dropout rate for CNN/ConvNet (Default: 0.0)
     :param nb_rnnoutdim: output dimension for the LSTM networks (Default: 1200)
     :param rnn_dropout: dropout rate for LSTM (Default: 0.2)

--- a/shorttext/classifiers/embed/sumvec/SumEmbedVecClassification.py
+++ b/shorttext/classifiers/embed/sumvec/SumEmbedVecClassification.py
@@ -23,11 +23,11 @@ class SumEmbeddedVecClassifier:
     <https://drive.google.com/file/d/0B7XkCwpI5KDYNlNUTTlSS21pQmM/edit>`_.
     """
 
-    def __init__(self, wvmodel, vecsize=300, simfcn=lambda u, v: 1-cosine(u, v)):
+    def __init__(self, wvmodel, vecsize=100, simfcn=lambda u, v: 1-cosine(u, v)):
         """ Initialize the classifier.
 
         :param wvmodel: Word2Vec model
-        :param vecsize: length of the embedded vectors in the model (Default: 300)
+        :param vecsize: length of the embedded vectors in the model (Default: 100)
         :param simfcn: similarity function (Default: cosine similarity)
         :type wvmodel: gensim.models.word2vec.Word2Vec
         :type vecsize: int

--- a/shorttext/classifiers/embed/sumvec/VarNNSumEmbedVecClassification.py
+++ b/shorttext/classifiers/embed/sumvec/VarNNSumEmbedVecClassification.py
@@ -24,11 +24,11 @@ class VarNNSumEmbeddedVecClassifier:
     <https://drive.google.com/file/d/0B7XkCwpI5KDYNlNUTTlSS21pQmM/edit>`_.
 
     """
-    def __init__(self, wvmodel, vecsize=300, maxlen=15):
+    def __init__(self, wvmodel, vecsize=100, maxlen=15):
         """ Initialize the classifier.
 
         :param wvmodel: Word2Vec model
-        :param vecsize: length of the embedded vectors in the model (Default: 300)
+        :param vecsize: length of the embedded vectors in the model (Default: 100)
         :param maxlen: maximum number of words in a sentence (Default: 15)
         :type wvmodel: gensim.models.word2vec.Word2Vec
         :type vecsize: int

--- a/shorttext/classifiers/embed/sumvec/frameworks.py
+++ b/shorttext/classifiers/embed/sumvec/frameworks.py
@@ -8,7 +8,7 @@ from shorttext.utils.classification_exceptions import UnequalArrayLengthsExcepti
 def DenseWordEmbed(nb_labels,
                    dense_nb_nodes=[],
                    dense_actfcn=[],
-                   vecsize=300,
+                   vecsize=100,
                    reg_coef=0.1,
                    final_activiation='softmax',
                    optimizer='adam'):
@@ -19,7 +19,7 @@ def DenseWordEmbed(nb_labels,
     :param nb_labels: number of class labels
     :param dense_nb_nodes: number of nodes in each later (Default: [])
     :param dense_actfcn: activation functions for each layer (Default: [])
-    :param vecsize: length of the embedded vectors in the model (Default: 300)
+    :param vecsize: length of the embedded vectors in the model (Default: 100)
     :param reg_coef: regularization coefficient (Default: 0.1)
     :param final_activiation: activation function of the final layer (Default: softmax)
     :param optimizer: optimizer for gradient descent. Options: sgd, rmsprop, adagrad, adadelta, adam, adamax, nadam. (Default: adam)


### PR DESCRIPTION
This PR makes the following changes : 
- Adding `with_gensim=True` codepaths for classes `DoubleCNNWordEmbed` and `CLSTMWordEmbed` (present in `shorttext.classifiers.embed.nnlib.frameworks.py`)
- Using `if with_gensim:` instead of `if with_gensim == True:`
- Changing default value of `vecsize` to 100 (from 300) 