### PR TITLE
Add missing functools import for reduce

### DIFF
--- a/shorttext/generators/bow/AutoEncodingTopicModeling.py
+++ b/shorttext/generators/bow/AutoEncodingTopicModeling.py
@@ -1,6 +1,7 @@
 
 import json
 import pickle
+from functools import reduce
 from operator import add
 
 import numpy as np


### PR DESCRIPTION
I stumbled across this while trying to use an autoencoder

It appears to be fixed somewhere else but not here, was that deliberate?