### PR TITLE
Changed link to Fasttext pretrained vectors

### DIFF
--- a/docs/tutorial_wordembed.rst
+++ b/docs/tutorial_wordembed.rst
@@ -78,7 +78,7 @@ FastText
 FastText is a similar word-embedding model from Facebook. You can download pre-trained models here:
 
 `Pre-trained word vectors
-<https://github.com/facebookresearch/fastText/blob/master/pretrained-vectors.md>`_
+<https://github.com/facebookresearch/fastText/blob/master/docs/pretrained-vectors.md>`_
 
 To load a pre-trained FastText model, run:
 


### PR DESCRIPTION
File moved from 
<https://github.com/facebookresearch/fastText/blob/master/pretrained-vectors.md> to <https://github.com/facebookresearch/fastText/blob/master/docs/pretrained-vectors.md>

Moved into docs folder.