### PR TITLE
Update keras import

### DIFF
--- a/shorttext/classifiers/bow/maxent/MaxEntClassification.py
+++ b/shorttext/classifiers/bow/maxent/MaxEntClassification.py
@@ -3,9 +3,9 @@ import pickle
 
 from scipy.sparse import dok_matrix
 from gensim.corpora import Dictionary
-from keras.models import Sequential
-from keras.layers import Dense
-from keras.regularizers import l2
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.layers import Dense
+from tensorflow.keras.regularizers import l2
 
 import shorttext.utils.kerasmodel_io as kerasio
 from ....utils import tokenize

--- a/shorttext/classifiers/embed/nnlib/frameworks.py
+++ b/shorttext/classifiers/embed/nnlib/frameworks.py
@@ -1,7 +1,7 @@
 
-from keras.layers import Conv1D, MaxPooling1D, Flatten, Dense, Dropout, LSTM, Activation
-from keras.models import Sequential
-from keras.regularizers import l2
+from tensorflow.keras.layers import Conv1D, MaxPooling1D, Flatten, Dense, Dropout, LSTM, Activation
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.regularizers import l2
 
 
 # Codes were changed because of Keras.

--- a/shorttext/classifiers/embed/sumvec/frameworks.py
+++ b/shorttext/classifiers/embed/sumvec/frameworks.py
@@ -1,7 +1,7 @@
 
-from keras.layers import Dense, Activation
-from keras.models import Sequential
-from keras.regularizers import l2
+from tensorflow.keras.layers import Dense, Activation
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.regularizers import l2
 
 from ....utils.classification_exceptions import UnequalArrayLengthsException
 

--- a/shorttext/cli/categorization.py
+++ b/shorttext/cli/categorization.py
@@ -33,7 +33,9 @@ def get_argparser():
     argparser.add_argument('--topn', type=int, default=10, help='Number of top-scored results displayed. (Default: 10)')
     argparser.add_argument('--inputtext', default=None, help='single input text for classification. Run console if set to None. (Default: None)')
     argparser.add_argument('--type', default='word2vec',
-                           help='Type of word-embedding model (default: "word2vec"; other options: "fasttext", "poincare", "word2vec_nonbinary", "poincare_binary")')
+                       choices=['word2vec', 'fasttext', 'poincare', 'word2vec_nonbinary', 'poincare_binary'],
+                       help='Type of word-embedding model ...')
+
     return argparser
 
 # main block

--- a/shorttext/cli/categorization.py
+++ b/shorttext/cli/categorization.py
@@ -33,9 +33,7 @@ def get_argparser():
     argparser.add_argument('--topn', type=int, default=10, help='Number of top-scored results displayed. (Default: 10)')
     argparser.add_argument('--inputtext', default=None, help='single input text for classification. Run console if set to None. (Default: None)')
     argparser.add_argument('--type', default='word2vec',
-                       choices=['word2vec', 'fasttext', 'poincare', 'word2vec_nonbinary', 'poincare_binary'],
-                       help='Type of word-embedding model ...')
-
+                           help='Type of word-embedding model (default: "word2vec"; other options: "fasttext", "poincare", "word2vec_nonbinary", "poincare_binary")')
     return argparser
 
 # main block

--- a/shorttext/generators/bow/AutoEncodingTopicModeling.py
+++ b/shorttext/generators/bow/AutoEncodingTopicModeling.py
@@ -6,9 +6,9 @@ from operator import add
 
 import numpy as np
 from gensim.corpora import Dictionary
-from keras import Input
-from keras import Model
-from keras.layers import Dense
+from tensorflow.keras import Input
+from tensorflow.keras import Model
+from tensorflow.keras.layers import Dense
 from scipy.spatial.distance import cosine
 
 from .LatentTopicModeling import LatentTopicModeler

--- a/shorttext/generators/seq2seq/charbaseS2S.py
+++ b/shorttext/generators/seq2seq/charbaseS2S.py
@@ -49,7 +49,7 @@ class CharBasedSeq2SeqGenerator(cio.CompactIOMachine):
         """ Compile the keras model.
 
         :param optimizer: optimizer for gradient descent. Options: sgd, rmsprop, adagrad, adadelta, adam, adamax, nadam. (Default: rmsprop)
-        :param loss: loss function available from keras (Default: 'categorical_crossentropy`)
+        :param loss: loss function available from tensorflow.keras (Default: 'categorical_crossentropy`)
         :return: None
         :type optimizer: str
         :type loss: str
@@ -79,7 +79,7 @@ class CharBasedSeq2SeqGenerator(cio.CompactIOMachine):
         :param batch_size: batch size (Default: 64)
         :param epochs: number of epochs (Default: 100)
         :param optimizer: optimizer for gradient descent. Options: sgd, rmsprop, adagrad, adadelta, adam, adamax, nadam. (Default: rmsprop)
-        :param loss: loss function available from keras (Default: 'categorical_crossentropy`)
+        :param loss: loss function available from tensorflow.keras (Default: 'categorical_crossentropy`)
         :return: None
         :type txtseq: str
         :type batch_size: int

--- a/shorttext/generators/seq2seq/s2skeras.py
+++ b/shorttext/generators/seq2seq/s2skeras.py
@@ -1,9 +1,9 @@
 
 import json
 
-from keras.models import load_model
-from keras.models import Model
-from keras.layers import Input, LSTM, Dense
+from tensorflow.keras.models import load_model
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Input, LSTM, Dense
 
 from ...utils import compactmodel_io as cio
 from ...utils import classification_exceptions as e
@@ -92,7 +92,7 @@ class Seq2SeqWithKeras(cio.CompactIOMachine):
         """ Compile the keras model after preparation running :func:`~prepare_model`.
 
         :param optimizer: optimizer for gradient descent. Options: sgd, rmsprop, adagrad, adadelta, adam, adamax, nadam. (Default: rmsprop)
-        :param loss: loss function available from keras (Default: 'categorical_crossentropy`)
+        :param loss: loss function available from tensorflow.keras (Default: 'categorical_crossentropy`)
         :type optimizer: str
         :type loss: str
         :return: None

--- a/shorttext/spell/sakaguchi.py
+++ b/shorttext/spell/sakaguchi.py
@@ -7,8 +7,8 @@ import json
 import numpy as np
 from gensim.corpora import Dictionary
 from sklearn.preprocessing import OneHotEncoder
-from keras.models import Sequential
-from keras.layers import LSTM, Activation, Dropout, Dense, TimeDistributed
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.layers import LSTM, Activation, Dropout, Dense, TimeDistributed
 
 import shorttext.utils.kerasmodel_io as kerasio
 from . import SpellCorrector

--- a/shorttext/stack/stacking.py
+++ b/shorttext/stack/stacking.py
@@ -3,9 +3,9 @@ import pickle
 from abc import ABC, abstractmethod
 
 import numpy as np
-from keras.layers import Dense, Reshape
-from keras.models import Sequential
-from keras.regularizers import l2
+from tensorflow.keras.layers import Dense, Reshape
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.regularizers import l2
 
 from ..utils import classification_exceptions as e
 from ..utils import kerasmodel_io as kerasio

--- a/shorttext/utils/kerasmodel_io.py
+++ b/shorttext/utils/kerasmodel_io.py
@@ -1,5 +1,5 @@
 
-from keras.models import model_from_json
+from tensorflow.keras.models import model_from_json
 
 
 def save_model(nameprefix, model):


### PR DESCRIPTION
Update Keras imports to use tensorflow.keras for TensorFlow 2.x compatibility

- The original code uses the standalone Keras package, which is not fully compatible with TensorFlow 2.x environments.
- TensorFlow 2.x officially integrates Keras as tensorflow.keras, which ensures better compatibility, stability, and access to the latest TensorFlow features.
- Using tensorflow.keras avoids potential conflicts and errors caused by mixing standalone Keras and TensorFlow modules.
